### PR TITLE
update MIDDLEWARE_CLASSES to MIDDLEWARE

### DIFF
--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/context_serializer.py
+++ b/djangojs/context_serializer.py
@@ -105,9 +105,9 @@ class ContextSerializer(object):
             'is_superuser': False,
             'permissions': tuple(),
         }
-        if 'django.contrib.sessions.middleware.SessionMiddleware' in settings.MIDDLEWARE_CLASSES:
+        if 'django.contrib.sessions.middleware.SessionMiddleware' in settings.MIDDLEWARE:
             user = self.request.user
-            data['user']['is_authenticated'] = user.is_authenticated()
+            data['user']['is_authenticated'] = user.is_authenticated
             data['user']['id'] = user.id
             if hasattr(user, 'username'):
                 data['user']['username'] = user.username

--- a/djangojs/settings.py
+++ b/djangojs/settings.py
@@ -104,7 +104,7 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
     'djangojs.tests.custom_processor',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -188,7 +188,7 @@ if 'jenkins' in sys.argv:
 if DEBUG:
     try:
         import debug_toolbar
-        MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+        MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
         INSTALLED_APPS += ('debug_toolbar',)
         INTERNAL_IPS = ('127.0.0.1',)
         DEBUG_TOOLBAR_CONFIG = {

--- a/djangojs/templatetags/js.py
+++ b/djangojs/templatetags/js.py
@@ -89,7 +89,7 @@ class VerbatimNode(template.Node):
         output = ""
         # If its text we concatenate it, otherwise it's a node and we render it
         for bit in self.text_and_nodes:
-            if isinstance(bit, basestring):
+            if isinstance(bit, str):
                 output += bit
             else:
                 output += bit.render(context)

--- a/djangojs/tests/test_context.py
+++ b/djangojs/tests/test_context.py
@@ -26,7 +26,7 @@ TEST_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
     'django.core.context_processors.i18n',
 )
 
-TEST_MIDDLEWARES = global_settings.MIDDLEWARE_CLASSES + (
+TEST_MIDDLEWARES = global_settings.MIDDLEWARE + (
     'django.middleware.locale.LocaleMiddleware',
 )
 
@@ -254,7 +254,7 @@ class ContextTestMixin(object):
 
 @override_settings(
     TEMPLATE_CONTEXT_PROCESSORS=TEST_CONTEXT_PROCESSORS,
-    MIDDLEWARE_CLASSES=TEST_MIDDLEWARES,
+    MIDDLEWARE=TEST_MIDDLEWARES,
     INSTALLED_APPS=['djangojs', 'djangojs.fake']
 )
 class ContextAsDictTest(ContextTestMixin, TestCase):
@@ -264,7 +264,7 @@ class ContextAsDictTest(ContextTestMixin, TestCase):
 
 @override_settings(
     TEMPLATE_CONTEXT_PROCESSORS=TEST_CONTEXT_PROCESSORS,
-    MIDDLEWARE_CLASSES=TEST_MIDDLEWARES,
+    MIDDLEWARE=TEST_MIDDLEWARES,
     INSTALLED_APPS=['djangojs', 'djangojs.fake']
 )
 class ContextAsJsonTest(ContextTestMixin, TestCase):
@@ -274,7 +274,7 @@ class ContextAsJsonTest(ContextTestMixin, TestCase):
 
 @override_settings(
     TEMPLATE_CONTEXT_PROCESSORS=TEST_CONTEXT_PROCESSORS,
-    MIDDLEWARE_CLASSES=TEST_MIDDLEWARES,
+    MIDDLEWARE=TEST_MIDDLEWARES,
     INSTALLED_APPS=['djangojs', 'djangojs.fake']
 )
 class ContextJsonViewTest(TestCase):


### PR DESCRIPTION
需要把  MIDDLEWARE_CLASSES 改为 MIDDLEWARE
但是暂时不能 merge，会影响线上的代码。
上线流程：
streetvoice 的 requirements 先使用 这个 branch
streetvoice 升级 python3.7 成功后：
先 merge 这个 branch 进 master
然后更新 streetvoice/requirements.txt （使用 django.js/master）
然后在删除这个branch